### PR TITLE
Optimized getting of row length in insert/delete/split

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -72,16 +72,13 @@ impl Row {
             return;
         }
         let mut result: String = String::new();
-        let mut length = 0;
         for (index, grapheme) in self.string[..].graphemes(true).enumerate() {
-            length += 1;
             if index == at {
-                length += 1;
                 result.push(c);
             }
             result.push_str(grapheme);
         }
-        self.len = length;
+        self.len += 1;
         self.string = result;
     }
     pub fn delete(&mut self, at: usize) {
@@ -89,14 +86,12 @@ impl Row {
             return;
         }
         let mut result: String = String::new();
-        let mut length = 0;
         for (index, grapheme) in self.string[..].graphemes(true).enumerate() {
             if index != at {
-                length += 1;
                 result.push_str(grapheme);
             }
         }
-        self.len = length;
+        self.len -= 1;
         self.string = result;
     }
     pub fn append(&mut self, new: &Self) {
@@ -107,17 +102,16 @@ impl Row {
         let mut row: String = String::new();
         let mut length = 0;
         let mut splitted_row: String = String::new();
-        let mut splitted_length = 0;
         for (index, grapheme) in self.string[..].graphemes(true).enumerate() {
             if index < at {
                 length += 1;
                 row.push_str(grapheme);
             } else {
-                splitted_length += 1;
                 splitted_row.push_str(grapheme);
             }
         }
 
+        let splitted_length = self.len - length;
         self.string = row;
         self.len = length;
         self.is_highlighted = false;


### PR DESCRIPTION
I looked at the the version https://github.com/pflenker/hecto-tutorial/tree/better-row-performance and here are my improvements of it. They allow to get rid of length counter.
I tested that insert/delete/split still works as expected with these changes.