### PR TITLE
Fixed a crash of editor when deleting multiple bytes characters in prompt

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use std::time::Instant;
 use termion::color;
 use termion::event::Key;
+use unicode_segmentation::UnicodeSegmentation;
 
 const STATUS_FG_COLOR: color::Rgb = color::Rgb(63, 63, 63);
 const STATUS_BG_COLOR: color::Rgb = color::Rgb(239, 239, 239);
@@ -388,7 +389,13 @@ impl Editor {
             self.refresh_screen()?;
             let key = Terminal::read_key()?;
             match key {
-                Key::Backspace => result.truncate(result.len().saturating_sub(1)),
+                Key::Backspace => {
+                    let graphemes_cnt = result.graphemes(true).count();
+                    result = result
+                        .graphemes(true)
+                        .take(graphemes_cnt.saturating_sub(1))
+                        .collect();
+                }
                 Key::Char('\n') => break,
                 Key::Char(c) => {
                     if !c.is_control() {


### PR DESCRIPTION
It fixes this issue:
If you enter a multiple bytes character, e.g. `ž` or `😒` in prompt after `Ctrl + F` or `Ctrl + S` and then delete the character by `Backspace`, editor crashes:

```
thread 'main' panicked at 'assertion failed: self.is_char_boundary(new_len)', /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/alloc/src/string.rs:1193:13
```