### PR TITLE
Fix usage of method multiline comments

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -328,7 +328,7 @@ impl Row {
         c: char,
         chars: &[char],
     ) -> bool {
-        if opts.comments() && c == '/' && *index < chars.len() {
+        if opts.multiline_comments() && c == '/' && *index < chars.len() {
             if let Some(next_char) = chars.get(index.saturating_add(1)) {
                 if *next_char == '*' {
                     let closing_index =


### PR DESCRIPTION
The method `opts.multiline_comments()` was defined but never was used.
Before fix: "Rust" has allowed both comment types, but if some language had allowed only single line comments, then multiple line comment would work too which is not desired.