### PR TITLE
Removed passing of references to objects which are already references

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -130,7 +130,7 @@ impl Document {
         };
         for _ in start..end {
             if let Some(row) = self.rows.get(position.y) {
-                if let Some(x) = row.find(&query, position.x, direction) {
+                if let Some(x) = row.find(query, position.x, direction) {
                     position.x = x;
                     return Some(position);
                 }
@@ -161,7 +161,7 @@ impl Document {
         #[allow(clippy::indexing_slicing)]
         for row in &mut self.rows[..until] {
             start_with_comment = row.highlight(
-                &self.file_type.highlighting_options(),
+                self.file_type.highlighting_options(),
                 word,
                 start_with_comment,
             );

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -153,7 +153,7 @@ impl Editor {
                     if let Some(position) =
                         editor
                             .document
-                            .find(&query, &editor.cursor_position, direction)
+                            .find(query, &editor.cursor_position, direction)
                     {
                         editor.cursor_position = position;
                         editor.scroll();

--- a/src/row.rs
+++ b/src/row.rs
@@ -238,7 +238,7 @@ impl Row {
                 }
             }
 
-            if self.highlight_str(index, &word, chars, hl_type) {
+            if self.highlight_str(index, word, chars, hl_type) {
                 return true;
             }
         }
@@ -437,15 +437,15 @@ impl Row {
             index = closing_index;
         }
         while let Some(c) = chars.get(index) {
-            if self.highlight_multiline_comment(&mut index, &opts, *c, &chars) {
+            if self.highlight_multiline_comment(&mut index, opts, *c, &chars) {
                 in_ml_comment = true;
                 continue;
             }
             in_ml_comment = false;
             if self.highlight_char(&mut index, opts, *c, &chars)
                 || self.highlight_comment(&mut index, opts, *c, &chars)
-                || self.highlight_primary_keywords(&mut index, &opts, &chars)
-                || self.highlight_secondary_keywords(&mut index, &opts, &chars)
+                || self.highlight_primary_keywords(&mut index, opts, &chars)
+                || self.highlight_secondary_keywords(&mut index, opts, &chars)
                 || self.highlight_string(&mut index, opts, *c, &chars)
                 || self.highlight_number(&mut index, opts, *c, &chars)
             {


### PR DESCRIPTION
Found by clippy.

E.g. for
```rust
self.highlight_primary_keywords(&mut index, &opts, &chars)
```
you get this warning
```rust
warning: this expression borrows a reference (`&filetype::HighlightingOptions`) that is immediately dereferenced by the compiler
   --> src/row.rs:447:64
    |
447 |                 || self.highlight_primary_keywords(&mut index, &opts, &chars)
    |                                                                ^^^^^ help: change this to: `opts`
    |
```
which is true, because `opts` is already a reference to `&HighlightingOptions`
