### PR TITLE
Fixed highligting during scrolling when comment row ends with */

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -412,14 +412,6 @@ impl Row {
     ) -> bool {
         let chars: Vec<char> = self.string.chars().collect();
         if self.is_highlighted && word.is_none() {
-            if let Some(hl_type) = self.highlighting.last() {
-                if *hl_type == highlighting::Type::MultilineComment
-                    && self.string.len() > 1
-                    && self.string[self.string.len() - 2..] == *"*/"
-                {
-                    return true;
-                }
-            }
             return false;
         }
         self.highlighting = Vec::new();


### PR DESCRIPTION
If you run `cargo run ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs` and scroll to (or find) the string `/* INVARIANT`

you get incorrectly parsed comments:

![image](https://user-images.githubusercontent.com/12584138/160913744-8d99d1a1-2684-4c50-833d-76dde9ed1f07.png)

The check of `*/` should produce `return false`, because ending `*/` means that multiple line comment is ended and doesn't continue on next line.

Actually I've found out that it's not needed to test multiline comments at all if row is already highlighted and just return `false` in all cases.
Then it works well (and editor is still fast and without issues, at least I didn't find any):

![image](https://user-images.githubusercontent.com/12584138/160915099-c3586025-4b46-4256-9302-7af852ff3097.png)
