### PR TITLE
fix highlighting bug with multi-line comments

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -415,10 +415,12 @@ impl Row {
             if let Some(hl_type) = self.highlighting.last() {
                 if *hl_type == highlighting::Type::MultilineComment
                     && self.string.len() > 1
-                    && self.string[self.string.len() - 2..] == *"*/"
+                    && self.string[self.string.len() - 2..] != *"*/"
                 {
                     return true;
                 }
+            } else if start_with_comment {
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
**why the change?**

to fix bug in: 
https://github.com/pflenker/hecto-tutorial/pull/15
https://github.com/pflenker/hecto-tutorial/issues/19

**what are the changes**

1.fix issues in https://github.com/pflenker/hecto-tutorial/pull/15
2.add a check for whether in multi-line comment for cases where current row is empty